### PR TITLE
CSS dropZone dynamically increases height

### DIFF
--- a/src/app/tab/tab.css
+++ b/src/app/tab/tab.css
@@ -111,7 +111,6 @@ body, p, ul {
 }
 
 .drop-zone-drop-container {
-    position: absolute;
     width: 186px;
     min-height: 70px;
     background-color: rgba(248, 248, 248, 1);
@@ -121,7 +120,6 @@ body, p, ul {
 }
 
 .drop-zone-drop-container-active {
-    position: absolute;
     width: 186px;
     min-height: 70px;
     background-color: rgba(204, 223, 237, 1);

--- a/src/app/tab/utils/utils-mock.service.js
+++ b/src/app/tab/utils/utils-mock.service.js
@@ -59,7 +59,7 @@ define(
                {id: "2", name: 'Field 2', state: false, category: 'Category 1'},
                {id: "3", name: 'Field 3', state: false, category: 'Category 1'}
            ]},
-       {name: 'dropZone3', id: 'dp3', label: 'Drop Zone 3', maxFields: 4, emptyLabel: 'Drop Any Field Here', active: false, disabled: false, required: true,
+       {name: 'dropZone3', id: 'dp3', label: 'Drop Zone 3', maxFields: 7, emptyLabel: 'Drop Any Field Here', active: false, disabled: false, required: true,
            currentFields:[
 
            ],


### PR DESCRIPTION
I've removed drop-zone.controller as it was supposed to be used for counting dropZoneHeight. But using position:static, height is calculated automatically according to content, so no need for it anymore.